### PR TITLE
Implemented richcompare for PyTag + fixed potential crashes

### DIFF
--- a/python_tests/test_tags.py
+++ b/python_tests/test_tags.py
@@ -1,4 +1,5 @@
 import pytest
+import operator
 import dbzero_ce as db0
 from .memo_test_types import MemoTestSingleton, MemoTestClass, MemoScopedClass, MemoDataPxClass
 from .conftest import DB0_DIR, DATA_PX
@@ -445,3 +446,28 @@ def test_tags_assigned_to_inherited_type_can_be_removed(db0_fixture):
     assert len(list(db0.find(MemoBaseClass, "tag1"))) == 0
     assert len(list(db0.find(MemoSubClass, "tag2"))) == 0
     assert len(list(db0.find(MemoBaseClass, "tag2"))) == 0
+
+def test_tags_compare(db0_fixture):
+    obj1 = MemoClassForTags(1)
+    obj2 = MemoClassForTags(2)
+    tag1 = db0.as_tag(obj1)
+    tag2 = db0.as_tag(obj2)
+
+    assert tag1 == tag1
+    assert tag1 == db0.as_tag(obj1)
+    assert (tag1 != db0.as_tag(obj1)) == False
+
+    assert tag1 != tag2
+    assert (tag1 == tag2) == False
+
+    for op in (operator.lt, operator.le, operator.ge, operator.gt):
+        with pytest.raises(TypeError):
+            op(tag1, tag1)
+        with pytest.raises(TypeError):
+            op(tag1, tag2)
+    
+    assert tag1 != 'test'
+    assert (tag1 == 'test') == False
+    assert tag1 != 123
+    assert tag1 != None
+    assert tag1 != []

--- a/src/dbzero/bindings/python/Memo.cpp
+++ b/src/dbzero/bindings/python/Memo.cpp
@@ -334,7 +334,7 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(!eq_result);
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
         }
     }
 

--- a/src/dbzero/bindings/python/collections/PyByteArray.cpp
+++ b/src/dbzero/bindings/python/collections/PyByteArray.cpp
@@ -220,10 +220,10 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(list_obj->ext() != other_list->ext());
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
             }
         } else {
-            return Py_NotImplemented;
+            Py_RETURN_NOTIMPLEMENTED;
         }
     }
 

--- a/src/dbzero/bindings/python/collections/PyList.cpp
+++ b/src/dbzero/bindings/python/collections/PyList.cpp
@@ -188,7 +188,7 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(list_obj->ext() != other_list->ext());
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
             }
         } else {
             PyObject *iterator = PyObject_GetIter(other);
@@ -199,7 +199,7 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(!has_all_elements_same(list_obj, iterator));
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
             }
 
             Py_DECREF(iterator);

--- a/src/dbzero/bindings/python/collections/PySet.cpp
+++ b/src/dbzero/bindings/python/collections/PySet.cpp
@@ -204,9 +204,9 @@ namespace db0::python
             return SetObject_issupersetInternal(set_obj, args, 1);
         }
         default:
-            return Py_NotImplemented;
+            Py_RETURN_NOTIMPLEMENTED;
         }
-        return Py_NotImplemented;
+        Py_RETURN_NOTIMPLEMENTED;
     }
     
     PyTypeObject SetObjectType = {

--- a/src/dbzero/bindings/python/collections/PyTuple.cpp
+++ b/src/dbzero/bindings/python/collections/PyTuple.cpp
@@ -79,7 +79,7 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(tuple_obj->ext() != other_tuple->ext());
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
             }
         } else {
             PyObject *iterator = PyObject_GetIter(other);
@@ -94,7 +94,7 @@ namespace db0::python
             case Py_NE:
                 return PyBool_fromBool(!has_all_elements_same(tuple_obj, iterator));
             default:
-                return Py_NotImplemented;
+                Py_RETURN_NOTIMPLEMENTED;
             }            
             Py_DECREF(iterator);
             Py_RETURN_TRUE;

--- a/src/dbzero/bindings/python/types/PyTag.cpp
+++ b/src/dbzero/bindings/python/types/PyTag.cpp
@@ -2,6 +2,7 @@
 #include <dbzero/bindings/python/Memo.hpp>
 #include <dbzero/object_model/object/Object.hpp>
 #include <dbzero/bindings/python/PyInternalAPI.hpp>
+#include <dbzero/bindings/python/Utils.hpp>
 
 namespace db0::python
 
@@ -22,6 +23,26 @@ namespace db0::python
         Py_TYPE(self)->tp_free((PyObject*)self);
     }
 
+    static PyObject *PyAPI_PyTag_richcompare(PyTag *self, PyObject *other, int op)
+    {
+        PY_API_FUNC
+        bool result = false;
+        if (PyTag_Check(other)) {
+            PyTag * other_tag = reinterpret_cast<PyTag*>(other);
+            result = self->ext() == other_tag->ext();
+        }
+
+        switch (op)
+        {
+            case Py_EQ:
+                return PyBool_fromBool(result);
+            case Py_NE:
+                return PyBool_fromBool(!result);
+            default:
+                Py_RETURN_NOTIMPLEMENTED;
+        }
+    }
+
     PyTypeObject PyTagType = {
         PyVarObject_HEAD_INIT(NULL, 0)
         .tp_name = "dbzero_ce.Tag",
@@ -29,6 +50,7 @@ namespace db0::python
         .tp_itemsize = 0,
         .tp_dealloc = (destructor)PyTag_del,
         .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_richcompare = (richcmpfunc)PyAPI_PyTag_richcompare,
         .tp_alloc = PyType_GenericAlloc,
         .tp_new = (newfunc)PyTag_new,
         .tp_free = PyObject_Free,
@@ -49,6 +71,7 @@ namespace db0::python
     
     PyObject *PyAPI_as_tag(PyObject *, PyObject *const *args, Py_ssize_t nargs)
     {
+        PY_API_FUNC
         if (nargs != 1) {
             PyErr_SetString(PyExc_TypeError, "Expected 1 argument");
             return NULL;

--- a/src/dbzero/object_model/tags/TagDef.cpp
+++ b/src/dbzero/object_model/tags/TagDef.cpp
@@ -14,5 +14,12 @@ namespace db0::object_model
     TagDef &TagDef::makeNew(void *at_ptr, std::uint64_t fixture_uuid, std::uint64_t value, ObjectPtr obj_ptr) {
         return *new (at_ptr) TagDef(fixture_uuid, value, obj_ptr);
     }
-    
+
+    bool TagDef::operator==(const TagDef &other) const {
+        return this->m_value == other.m_value && this->m_fixture_uuid == other.m_fixture_uuid;
+    }
+
+    bool TagDef::operator!=(const TagDef &other) const {
+        return !(*this == other);
+    }
 }

--- a/src/dbzero/object_model/tags/TagDef.hpp
+++ b/src/dbzero/object_model/tags/TagDef.hpp
@@ -22,6 +22,9 @@ namespace db0::object_model
         TagDef(std::uint64_t fixture_uuid, std::uint64_t value, ObjectPtr);
                 
         static TagDef &makeNew(void *at_ptr, std::uint64_t fixture_uuid, std::uint64_t value, ObjectPtr);
+
+        bool operator==(const TagDef &other) const;
+        bool operator!=(const TagDef &other) const;
     };
     
 }


### PR DESCRIPTION
issues-253 + fixed crashes caused by use of unsupported operators in richcompare functions