### PR TITLE
fixed sigsegv for path as input file

### DIFF
--- a/python_tests/test_copy_prefix.py
+++ b/python_tests/test_copy_prefix.py
@@ -283,6 +283,5 @@ def test_copy_prefix_throws_on_path_passed(db0_fixture):
         root.value.append(MemoTestClass("a" * 1024))  # 1 KB string
     db0.commit()
     
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(OSError) as excinfo:
         db0.copy_prefix(path)
-    assert "Output file points to a directory:" in str(excinfo.value)

--- a/src/dbzero/bindings/python/PyInternalAPI.cpp
+++ b/src/dbzero/bindings/python/PyInternalAPI.cpp
@@ -937,12 +937,14 @@ namespace db0::python
         std::optional<std::uint64_t> page_io_step_size, std::optional<std::uint64_t> meta_io_step_size) 
     {
         // make sure output is file doesn't point to a directory
-        if (output_file_name.back() == '\\' || output_file_name.back() == '/') {
-            THROWF(db0::IOException) << "Output file points to a directory: " << output_file_name;
+        if (output_file_name.back() == std::filesystem::path::preferred_separator) {
+            PyErr_Format(PyExc_OSError, "Output file points to a directory:  '%s'", output_file_name);
+            return nullptr;
         }
         // make sure output file does not exist
         if (db0::CFile::exists(output_file_name)) {
-            THROWF(db0::IOException) << "Output file already exists: " << output_file_name;
+            PyErr_Format(PyExc_OSError, "Output file already exists:  '%s'", output_file_name);
+            return nullptr;
         }
                 
         // use either explicit step size, input step size (if > 1) or default = 4MB
@@ -1037,6 +1039,9 @@ namespace db0::python
             auto result = Py_OWN(tryCopyPrefixImpl(*storage, output_file_name, page_io_step_size, meta_io_step_size));
             storage->close();
             return result.steal();
+            if (!result) {
+                return nullptr;
+            }
         } catch (...) {
             if (storage) {
                 storage->close();


### PR DESCRIPTION
fix(copy_prefix): prevent sigsegv when path is passed as output

Passing directory as output to copy_prefix causes SigSegv during execution

Fixes #537