### PR TITLE
fix(workspace): prevent invalid exception when opening prefix in RW m…

### DIFF
--- a/src/dbzero/bindings/python/types/PyEnumType.cpp
+++ b/src/dbzero/bindings/python/types/PyEnumType.cpp
@@ -124,7 +124,7 @@ namespace db0::python
             auto prefix_name_ptr = m_enum_type_def->getPrefixNamePtr();
             if (prefix_name_ptr) {
                 // make the error message more informative
-                THROWF(db0::InputException) << "Prefix does not exist or unable to open: " << prefix_name_ptr;
+                THROWF(db0::PrefixNotFoundException) << "Prefix does not exist or unable to open: " << prefix_name_ptr;
             }
             THROWF(db0::InputException) << "Unable to resolve the scope of: " << *m_enum_type_def;
         }

--- a/src/dbzero/core/exception/Exceptions.cpp
+++ b/src/dbzero/core/exception/Exceptions.cpp
@@ -72,4 +72,9 @@ namespace db0
     {        
     }
 
+    PrefixNotFoundException::PrefixNotFoundException()
+        : RecoverableException(exception_id)
+    {
+    }
+
 }

--- a/src/dbzero/core/exception/Exceptions.hpp
+++ b/src/dbzero/core/exception/Exceptions.hpp
@@ -128,4 +128,11 @@ namespace db0
         CacheException();
     };
 
+    class PrefixNotFoundException: public RecoverableException
+    {
+    public:
+        static constexpr int exception_id = EXCEPTION_ID_PREFIX::BASIC | 0x10;
+        PrefixNotFoundException();
+    };
+
 }

--- a/src/dbzero/workspace/PrefixCatalog.cpp
+++ b/src/dbzero/workspace/PrefixCatalog.cpp
@@ -53,7 +53,7 @@ namespace db0
         auto file_name = getFileName(prefix_name);
         bool file_exists = CFile::exists(file_name.string());
         if (!if_exists && !file_exists) {
-            THROWF(db0::InputException) << "Prefix does not exist: " << prefix_name;
+            THROWF(db0::PrefixNotFoundException) << "Prefix does not exist: " << prefix_name;
         }        
         if (file_exists) {
             std::remove(file_name.string().c_str());
@@ -203,7 +203,7 @@ namespace db0
     fs::path FixtureCatalog::getPrefixFileName(const PrefixName &prefix_name) const 
     {
         if (!m_prefix_catalog.exists(prefix_name)) {
-            THROWF(db0::InputException) << "Prefix does not exist: " << prefix_name;
+            THROWF(db0::PrefixNotFoundException) << "Prefix does not exist: " << prefix_name;
         }
         return m_prefix_catalog.getFileName(prefix_name);
     }


### PR DESCRIPTION
fix(workspace): prevent invalid exception when opening prefix in RW mode fails

Fixed issue #334 where opening a locked prefix in read-write mode would throw exception and Workspace open silences exception and returns null. Right now null is returned only when PrefixNotFoundException is thrown.

Changes:
- Added new exception type PrefixNotFoundException for clearer error handling
- Modified PrefixCatalog, Workspace, and PyEnumType to throw PrefixNotFoundException instead of InputException when prefix does not exist
- Improved error handling in Workspace::open() to properly clean up incomplete files for all exception types while preserving the original exception for non-prefix-not-found cases

Fixes #334